### PR TITLE
Fix loading of package

### DIFF
--- a/skewer-repl.el
+++ b/skewer-repl.el
@@ -103,7 +103,6 @@
       (skewer-repl-mode)))
   (pop-to-buffer (get-buffer "*skewer-repl*")))
 
-;;;###autoload
 (eval-when (load eval)
   (add-hook 'skewer-response-hook #'skewer-repl--response-hook)
   (define-key skewer-mode-map (kbd "C-c C-z") #'skewer-repl))


### PR DESCRIPTION
I'm not sure if the autoloading was intentional, but it breaks Emacs startup since `skewer-mode-map` isn't defined when Emacs loads the autoloads file.
