### PR TITLE
Fixed an error if no hexl program can be found.

### DIFF
--- a/skewer-repl.el
+++ b/skewer-repl.el
@@ -42,7 +42,9 @@
   (setq comint-prompt-regexp (concat "^" (regexp-quote skewer-repl-prompt)))
   (setq comint-input-sender 'skewer-input-sender)
   (unless (comint-check-proc (current-buffer))
-    (start-process "ielm" (current-buffer) "hexl")
+    (condition-case nil
+        (start-process "ielm" (current-buffer) "hexl")
+      (file-error (start-process "ielm" (current-buffer) "cat")))
     (set-process-query-on-exit-flag (skewer-repl-process) nil)
     (goto-char (point-max))
     (set (make-local-variable 'comint-inhibit-carriage-motion) t)


### PR DESCRIPTION
When I run skewer-repl I got an error saying no hexl program could be found. Not sure why this started happening but this patch fixed the issue.
