### PR TITLE
Skewer-html mode (like skewer-css)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Skewer -- live Emacs JavaScript and CSS interaction
+# Skewer -- live Emacs JavaScript, CSS, and HTML interaction
 
-Provides live interaction with JavaScript and CSS in a web browser.
+Provides live interaction with JavaScript, CSS, and HTML in a web browser.
 Expressions are sent on-the-fly from an editing buffer to be evaluated
 in the browser, just like Emacs does with an inferior Lisp process in
 Lisp modes.


### PR DESCRIPTION
Hi there,

I have written a `skewer-html` mode using `skewer-css` as a base. The additional JavaScript hasn't yet been tested on IE (which I guess will need a quick fix for the innerHTML), but otherwise this is working great for me.

It adds a few functions that allow you to "eval" HTML (`skewer-html-eval`, and interactive helpers), which in this case translates to appending HTML to the body, but using the prefix argument you can easily specify an alternative selector and choose to replace instead of append. There is also another function that lets you pull HTML from a selector into the current buffer (`skewer-html-fetch-selector`), which I find useful if I have been appending stuff for a while.

I have also updated the README to reflect the new keybindings.

Let me know if anything seems a bit off with this patch, but hopefully all is good and can be merged as is.

Cheers,
Zane
