### PR TITLE
Make skewer-setup.el byte-compilable

### DIFF
--- a/skewer-setup.el
+++ b/skewer-setup.el
@@ -9,6 +9,8 @@
 
 ;;; Code:
 
+(load "skewer-mode-autoloads" nil t)
+
 ;;;###autoload
 (defun skewer-setup ()
   "Fully integrate Skewer into js2-mode, css-mode, and html-mode buffers."


### PR DESCRIPTION
Batch-compiling skewer produced this error:

```
Required feature `skewer-mode-autoloads' was not provided.
```

Using "load" in place of "require" resolves that issue.
