### PR TITLE
Report error location in skewer-repl

### DIFF
--- a/skewer.js
+++ b/skewer.js
@@ -344,7 +344,10 @@ skewer.error = function(event) {
     "use strict";
     var log = {
         type: "error",
-        value: event.message
+        value: event.message,
+        filename: event.filename,
+        line: event.lineno,
+        column: event.column
     };
     skewer.postJSON(skewer.host + "/skewer/post", log);
 };


### PR DESCRIPTION
This change adds line with file name and column where error is reported. 

It takes advantage of emacs built-in compilation error highlighting. If you set up 'skewer-path-strip-level' and 'compilation-search-path' right according to your project, you will be even able to clik on error line in skewer-repl buffer, and you will be taken to file and line where error occurred. Very useful if you do TDD style development.
