### PR TITLE
Explicitly require emacs 24

### DIFF
--- a/skewer-mode-pkg.el
+++ b/skewer-mode-pkg.el
@@ -1,3 +1,3 @@
 (define-package "skewer-mode" "1.5.3"
   "live browser JavaScript, CSS, and HTML interaction"
-  '((simple-httpd "1.4.0") (js2-mode "20090723")))
+  '((simple-httpd "1.4.0") (js2-mode "20090723") (emacs "24")))


### PR DESCRIPTION
The code uses `lexical-binding`, so although `js2-mode` depends on Emacs 24, it's best if `skewer-mode` also makes the dependency explicit.
