### PR TITLE
Remove reference to spurious "foo" variable

### DIFF
--- a/skewer-mode.el
+++ b/skewer-mode.el
@@ -559,7 +559,6 @@ inconsistent buffer."
 
 (defun skewer-phantomjs-sentinel (proc event)
   "Cleanup after phantomjs exits."
-  (setf foo event)
   (when (some (lambda (s) (string-match-p s event))
               '("finished" "abnormal" "killed"))
     (delete-file (process-get proc 'tempfile))))


### PR DESCRIPTION
Prevents the following byte-compilation warning:

```
skewer-mode.el:562:9:Warning: assignment to free variable `foo'
```

Note that a number of other warnings remain:

```
skewer-mode.el:126:1:Warning: cl package required at runtime
skewer-mode.el:182:1:Warning: Unused lexical argument `error-case'
skewer-mode.el:254:1:Warning: Unused lexical argument `args'
skewer-mode.el:254:1:Warning: Unused lexical argument `query'
skewer-mode.el:254:1:Warning: Unused lexical argument `path'
skewer-mode.el:257:1:Warning: Unused lexical variable `type'
skewer-mode.el:257:1:Warning: Unused lexical argument `args'
skewer-mode.el:257:1:Warning: Unused lexical argument `query'
skewer-mode.el:257:1:Warning: Unused lexical argument `path'
```
