### PR TITLE
Don't rely on css-backward-sexp

### DIFF
--- a/skewer-css.el
+++ b/skewer-css.el
@@ -54,7 +54,7 @@
   "Move to the end of the current declaration and return point."
   (skewer-css-end-of-declaration)
   (re-search-backward ":")
-  (css-backward-sexp 1)
+  (backward-sexp 1)
   (point))
 
 (defun skewer-css-selectors ()


### PR DESCRIPTION
In recent Emacs snapshots, there's no longer a css-backward-sexp, so `skewer-css-beginning-of-declaration` will produce an error.

I'd expect that plain old `backward-sexp` should do the trick, but I admit that I haven't confirmed this. :-)
