### PR TITLE
Add stylesheet reloading

### DIFF
--- a/skewer-css.el
+++ b/skewer-css.el
@@ -10,6 +10,7 @@
 ;; * C-x C-e -- `skewer-css-eval-current-declaration'
 ;; * C-M-x   -- `skewer-css-eval-current-rule'
 ;; * C-c C-k -- `skewer-css-eval-buffer'
+;; * C-c C-r -- `skewer-css-reload-buffer'
 
 ;; These functions assume there are no comments within a CSS rule,
 ;; *especially* not within a declaration. In the former case, if you
@@ -106,6 +107,23 @@
   (interactive)
   (skewer-css (buffer-substring-no-properties (point-min) (point-max))))
 
+(defun skewer-css-reload-buffer ()
+  "Reload the current buffer IF it is already included as a link tag."
+  (interactive)
+
+  (save-buffer)
+
+  ;; TODO I tried to use skewer-apply, but it said skewer.reloadStylesheet was
+  ;; not a valid function.
+  (skewer-eval (concat "skewer.reloadStylesheet(\"" (buffer-file-name) "\");")))
+
+(defun skewer-css-add-reload-stylesheet-js ()
+  "Hook function to insert JS needed to reload a CSS file on demand."
+  (insert-file-contents
+   (expand-file-name "skewer-reload-stylesheet.js" skewer-data-root)))
+
+(add-hook 'skewer-js-hook 'skewer-css-add-reload-stylesheet-js)
+
 ;; Minor mode definition
 
 (defvar skewer-css-mode-map
@@ -113,7 +131,8 @@
     (prog1 map
       (define-key map (kbd "C-x C-e") 'skewer-css-eval-current-declaration)
       (define-key map (kbd "C-M-x") 'skewer-css-eval-current-rule)
-      (define-key map (kbd "C-c C-k") 'skewer-css-eval-buffer)))
+      (define-key map (kbd "C-c C-k") 'skewer-css-eval-buffer)
+      (define-key map (kbd "C-c C-r") 'skewer-css-reload-buffer)))
   "Keymap for skewer-css-mode.")
 
 ;;;###autoload

--- a/skewer-reload-stylesheet.js
+++ b/skewer-reload-stylesheet.js
@@ -1,0 +1,37 @@
+// Reload any stylesheet imported from `path` by removing then re-inserting its
+// link tag.
+// Return false if no stylesheet was found, or true if it was.
+skewer.reloadStylesheet = function(path) {
+    'use strict';
+
+    var endsWith = function(str, suffix) {
+        return str.indexOf(suffix, str.length - suffix.length) !== -1;
+    }
+
+    // Find the <link> tag importing the stylesheet at `path` (if any).
+    var link_elts = document.getElementsByTagName('link');
+
+    var target_link = null;
+    var cur_href = null;
+    var max_href_len = 0;
+
+    for (var i = 0; i < link_elts.length; i++) {
+        cur_href = link_elts[i].getAttribute('href');
+        if (endsWith(path, cur_href) && cur_href.length > max_href_len) {
+            target_link = link_elts[i];
+            max_href_len = cur_href.length;
+        }
+    }
+
+    if (target_link === null) {
+        return false;
+    }
+
+    // Swap the original link tag in and out of the DOM to force a stylesheet
+    // reload from disk.
+    var placeholder = document.createElement('link');
+    target_link.parentNode.replaceChild(placeholder, target_link);
+    placeholder.parentNode.replaceChild(target_link, placeholder);
+
+    return true;
+}

--- a/test/base.css
+++ b/test/base.css
@@ -1,3 +1,4 @@
 .base-styles {
     color: blue;
+    background-color: yellow;
 }

--- a/test/overrides.css
+++ b/test/overrides.css
@@ -1,3 +1,5 @@
 .overrides {
     color: red;
+    background-color: transparent;
+    font-size: 1em;
 }

--- a/test/subdir/base.css
+++ b/test/subdir/base.css
@@ -1,0 +1,3 @@
+.subdir-base-styles {
+    font-size: 48px;
+}

--- a/test/test-css-reloading.html
+++ b/test/test-css-reloading.html
@@ -1,12 +1,25 @@
+<!-- A very simple testbed for Skewer's stylesheet reloading feature.
+
+Pop this open in your browser of choice and try live-editing the stylesheets.
+
+Note that subdir/base.css is there to verify that we get the right link tag,
+even in the face of matching filenames.
+
+ -->
 <html>
     <head>
         <link rel="stylesheet" type="text/css" href="base.css" />
+        <link rel="stylesheet" type="text/css" href="subdir/base.css" />
         <link rel="stylesheet" type="text/css" href="overrides.css" />
     </head>
 
     <body>
         <div class="base-styles">
             <p>This should be boring.</p>
+        </div>
+
+        <div class="base-styles subdir-base-styles">
+            <p>This should get the subdir's styles.</p>
         </div>
 
         <div class="base-styles overrides">


### PR DESCRIPTION
First, skewer is awesome. I discovered it last week and fell in love with it. Thank you so much for making it.

When I tried it out at work, I ran into yet another frustration with one of our legacy codebases. That codebase has quite a few messily intertwined stylesheets with hundreds of rules with overly-general selectors. Thus, what I saw while live-editing with skewer didn't necessarily relate at all to what I'd see after a refresh. Sending a whole stylesheet would change its specificity, drastically changing the way a page would render.

As I ate lunch that day, I pondered what it would take to make skewer more useful in a hairball like our codebase. The approach in this merge request occurred to me, so I tried it out, and at least in my simple test case (which should maybe be removed or improved before merging), it seems to work quite well.

`skewer-css` gets a new function called `skewer-css-reload-buffer` that saves the current buffer, then asks all skewer clients to reload the stylesheet whose href best matches the filepath to the current buffer. For the moment, that's bound to `C-c C-r`.

I was thinking it might make sense to make this C-c C-k's default action. If no matching link tag is found, then we could fall back to inserting the stylesheet via style tag. I figured I should get feedback before trying that, though.

This has only been tested in Chrome so far - I'd assume most browsers would behave correctly on removing stylesheets and adding them, but I'm always suspicious of the older IEs.

Any requests, complaints, etc, just ask, and I'll see what I can do.

Again, thanks for skewer! It's awesome, and I hope this can make it awesomer for other people stuck with messes they didn't make.
