### PR TITLE
Don't signal error on phantomjs kill.

### DIFF
--- a/skewer-mode.el
+++ b/skewer-mode.el
@@ -584,7 +584,10 @@ inconsistent buffer."
 (defun skewer-phantomjs-kill ()
   "Kill all inferior phantomjs processes connected to Skewer."
   (interactive)
-  (mapc #'kill-process skewer-phantomjs-processes))
+  (mapc (lambda(process)
+	  (when (eq (process-status process) 'run)
+	    (kill-process process)))
+	skewer-phantomjs-processes))
 
 (provide 'skewer-mode)
 


### PR DESCRIPTION
With this modification there is no error when killing PhantomJS.
