### PR TITLE
Add instruction on how to visit HTML document from browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ To skewer your own document rather than the provided blank one,
 
 #### How to visit HTML file
 
-To view an HTML file being developed, do the following:
+To visit an HTML document, do the following:
 
-1. `(setq httpd-root "~/web-page-making")` web-page-making is the directory where the HTML file to be visited is.
-2. At your browser's URL field enter: `http://127.0.0.1:8080/index.html` 8080 is the value of `httpd-port` and `index.html` is the HTML file name.
-
+1. `(setq httpd-root "~/web-page-making")` `web-page-making` is the directory where the HTML document to be visited is.
+2. At your browser's URL field enter: `http://127.0.0.1:8080/index.html` `8080` is the value of `httpd-port` and `index.html` is the HTML document name.
 
 
 Skewer fully supports CORS so the document need not be hosted by Emacs

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ To skewer your own document rather than the provided blank one,
     (see example.html and check your `httpd-port`)
  5. Visit the document from your browser
 
+#### How to visit HTML file
+
+To view an HTML file being developed, do the following:
+
+1. `(setq httpd-root "~/web-page-making")` web-page-making is the directory where the HTML file to be visited is.
+2. At your browser's URL field enter: `http://127.0.0.1:8080/index.html` 8080 is the value of `httpd-port` and `index.html` is the HTML file name.
+
+
+
 Skewer fully supports CORS so the document need not be hosted by Emacs
 itself. A Greasemonkey userscript is provided, *Skewer Everything*,
 for injecting Skewer into any arbitrary page you're visiting without


### PR DESCRIPTION
It took me 45 minutes by googling to figure out how to actually do "Visit the document from your browser" as a new user. So I feel that the time can be saved by adding the instruction of how to in README.md:
+1. `(setq httpd-root "~/web-page-making")` `web-page-making` is the directory where the HTML document to be visited is.
+2. At your browser's URL field enter: `http://127.0.0.1:8080/index.html` `8080` is the value of `httpd-port` and `index.html` is the HTML document name.