### PR TITLE
Note browser plugins for auto-skewering some URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Alternatively, the following bookmarklet will load skewer on demand:
 javascript:(function(){var d=document;var s=d.createElement('script');s.src='http://localhost:8080/skewer';d.body.appendChild(s);})()
 ```
 
+With a browser plugin like
+[Custom Javascript for Websites](https://chrome.google.com/webstore/detail/custom-javascript-for-web/poakhlngfciodnhlhhgnaaelnpjljija?hl=en),
+you can use the bookmarklet to auto-skewer specific domains, saving you a
+mouse click on each reload.
+
 ## bower
 
 Also provided are some functions for loading libraries from the bower


### PR DESCRIPTION
I generally use the bookmarklet when I want to skewer a page, but when
I'm coding, it's annoying to re-skewer after refreshing.

I don't like loading skewer directly in a codebase's markup/templates,
because then I have to remember not to commit that tweak.

Since there's a simple way to have dev-friendly browsers skewer dev
environments automatically, it seemed worth documenting.