### PR TITLE
Add metadata for utf-8 coding

### DIFF
--- a/example.html
+++ b/example.html
@@ -3,6 +3,7 @@
   <head>
     <title>Skewer</title>
     <script src="/skewer"></script>
+    <meta charset="utf-8">
   </head>
   <body>
   </body>


### PR DESCRIPTION
If not, some characters (such as chinese) can't display correctly in web pages and logs