### PR TITLE
Pretender preventer

### DIFF
--- a/skewer-everything.user.js
+++ b/skewer-everything.user.js
@@ -6,7 +6,10 @@
 // @license      Public Domain
 // @include      /^https?:///
 // @grant        none
+// @run-at       document-start
 // ==/UserScript==
+
+window.NativeXHR = XMLHttpRequest;
 
 var host = 'http://localhost:8080';
 

--- a/skewer-everything.user.js
+++ b/skewer-everything.user.js
@@ -10,6 +10,7 @@
 // ==/UserScript==
 
 window.NativeXHR = XMLHttpRequest;
+window.skewer = inject;
 
 var host = 'http://localhost:8080';
 

--- a/skewer.js
+++ b/skewer.js
@@ -33,7 +33,8 @@ function skewer() {
  * @param {Function} [callback] The callback to receive a response object
  */
 skewer.getJSON = function(url, callback) {
-    var xhr = new XMLHttpRequest();
+    var XHR = NativeXHR || XMLHttpRequest;
+    var xhr = new XHR();
     xhr.onreadystatechange = function() {
         if (xhr.readyState === 4 && xhr.status === 200) {
             callback(JSON.parse(xhr.responseText));
@@ -50,7 +51,8 @@ skewer.getJSON = function(url, callback) {
  * @param {Function} [callback] The callback to receive a response object
  */
 skewer.postJSON = function(url, object, callback) {
-    var xhr = new XMLHttpRequest();
+    var XHR = NativeXHR || XMLHttpRequest;
+    var xhr = new XHR();
     xhr.onreadystatechange = function() {
         if (callback && xhr.readyState === 4 && xhr.status === 200) {
             callback(JSON.parse(xhr.responseText));


### PR DESCRIPTION
## TL;DR:

Fix skewer on pages which mess with XMLHttpRequest causing CORS issues - pretender, mirage, etc.

## What does it do?

1. Configures the user script to be loaded before the page document.
2. Captures and exposes the untampered native XMLHttpRequest object.
3. Exposes the injector function for manual activation - in case your ember page obliterates all divs that came before it (like mine seems to do).
4. Use the native XHR in POST/GET requests.

## Details

After spending more time than I would have liked trying to make pretender/mirage/ember to stop breaking by skewer requests I gave up and found a solution that will always work without messing with the server.

Specifically I was getting a missing `Access-Control-Allow-Origin` header error, in turn caused by a nil JSON block being sent back to emacs, throwing a `(json-end-of-file)` error, and thus not sending back a proper response.

...or something like that, I'm neither an elisp nor http expert.

## Anything left to do?

- You might like to add a simple bookmarklet which calls `skewer` with a single click.
- Not sure if `window.skewer` might conflict with `skewer.fn` in some way?